### PR TITLE
Remove debugging output from imports

### DIFF
--- a/backtesting_script.py
+++ b/backtesting_script.py
@@ -8,7 +8,7 @@ import sys
 import ast # For converting string representation of dict back to dict
 import random # For Monte Carlo Simulation
 
-print("Imports successful")
+# print("Imports successful")
 
 DEFAULT_START_DATE = datetime.datetime(2023, 1, 1) 
 DEFAULT_END_DATE = datetime.datetime(2023, 1, 3)   


### PR DESCRIPTION
## Summary
- comment out `Imports successful` message in `backtesting_script.py`

## Testing
- `python backtesting_script.py` *(fails: No module named 'backtrader')*

------
https://chatgpt.com/codex/tasks/task_e_6847d2c45cf0832483c036c64396d9f6